### PR TITLE
Add parent CONTRIBUTING document with AI usage policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to StreamsHub
+
+Thank you for your interest in contributing to the StreamsHub organization.
+All contributors are expected to follow the StreamsHub [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+Individual sub-projects within the StreamsHub organization maintain their own contributing guides with project-specific details such as build instructions, coding conventions, and testing requirements.
+This document covers organization-wide contribution policies that apply across all StreamsHub sub-projects.
+
+For information on governance, roles, and voting, see the [Governance Policy](./GOVERNANCE.md).
+
+## AI Contribution Policy
+
+### Overview
+
+Contributors may use AI tools, such as Large Language Models (LLMs), code assistants, and coding agents, when contributing to StreamsHub.
+As with any development tool, the contributor is responsible for the quality of the result and for understanding what they submit.
+
+**You are the contributor.**
+When you submit a Pull Request (PR) to any StreamsHub sub-project, you certify the contribution as your own work.
+AI-generated or AI-assisted content does not change this responsibility.
+
+### Understanding and Responsibility
+
+* You must understand your contribution: Do not submit code, documentation, or other content that you do not fully understand. You should be able to explain to reviewers what your contribution does, how it works, and how you verified it.
+* Review all AI-generated content: Before submitting, verify that the contribution is correct, tested, and follows the sub-project's contributing guidelines.
+* You own what you submit: As the PR author, you are responsible for all changes, regardless of the tools used to create them. You must certify that you wrote or otherwise have the right to submit the code you are contributing by signing your commits.
+
+### Disclosure
+
+#### When disclosure is required
+
+Disclosure is required when AI tools generate substantial content for your contribution.
+Using AI features similar to routine IDE capabilities does not require disclosure.
+
+**Does not require disclosure:**
+
+* Autocomplete and code completion suggestions such as arguments, functions names etc.
+* Syntax and formatting suggestions
+* Variable or method name suggestions
+
+**Requires disclosure:**
+
+* Functions, classes, or significant code blocks
+* Test cases or test suites
+* Documentation content
+* Bug fix implementations
+
+#### How to disclose
+
+Commits with substantial AI assistance must include an `Assisted-by` trailer identifying the tool used.
+For example:
+
+```
+Assisted-by: GitHub Copilot
+Assisted-by: Claude Sonnet 4
+```
+
+You can add this trailer using:
+
+```bash
+git commit -m "Your commit message
+
+Assisted-by: ToolName"
+```
+
+AI tools can also be configured to add this trailer automatically on commit.
+
+If AI tools were used significantly across a PR, note this in the PR description as well to give reviewers additional context.
+
+#### Commit trailer restrictions
+
+AI tools **must not** appear in `Signed-off-by`, `Co-authored-by`, `Co-developed-by`, or similar commit trailers that imply authorship or legal certification.
+Only humans can certify the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+AI is not a legal entity and cannot make this certification.
+
+### What Not to Do
+
+* Do not submit code you do not understand: If you cannot explain the reasoning behind your changes during review, the PR may be closed.
+* Do not let AI respond to reviewers on your behalf: When maintainers, component owners, or other contributors provide feedback on your PR, you may use AI tools to help formulate responses, but you must fully understand and take ownership of what you write. Reviewers want to engage with you, not receive generic AI-generated responses.
+* Do not submit large, unfocused PRs: AI tools can generate content faster than reviewers can read it. Keep PRs focused and appropriately sized. Maintainers may close pull requests that are too large to review effectively or where the contributor does not appear to understand the changes.
+* Do not open multiple AI-generated PRs in rapid succession: Submitting many PRs at once overwhelms reviewers and may result in PRs being closed.
+* Avoid unnecessary verbosity: Trim down AI-generated PR descriptions, commit messages, and code comments. Be clear, concise, and specific. Respect the time of maintainers and reviewers.
+
+### Quality Standards
+
+* Meet the same standards: AI-assisted contributions are reviewed to the same standard as any other contribution. Code must be correct, maintainable, well-tested, and consistent with sub-project conventions.
+* Ensure licensing compliance: You must ensure that AI-generated content does not introduce material under licenses incompatible with the project's [Apache 2.0 License](./LICENSE).
+* Test your changes: All code contributions must be tested according to the sub-project's standards, whether AI-assisted or not.
+
+### AI-Assisted Pull Request Reviews
+
+Automated or AI-assisted reviews can supplement the review process but do not replace review by maintainers or component owners.
+
+* AI reviews do not replace human review: AI-generated review comments can provide useful signals, but they do not satisfy the project's [review requirements](./GOVERNANCE.md#pr-approval-rules).
+* Humans make the decisions: Maintainers and component owners make merge decisions following the project's [governance framework](./GOVERNANCE.md#pr-approval-rules).
+* Do not invoke AI review tools on project PRs: While you may use AI tools to review your code privately during development, do not invoke AI bots or tools to post review comments on StreamsHub PRs. Where AI-assisted review is desired, maintainers will request it.
+
+### Consequences of Non-Compliance
+
+Pull requests that violate this policy may be closed. This includes:
+
+* PRs where the contributor cannot explain or defend the changes during review.
+* PRs with generic, inauthentic responses to reviewer feedback that demonstrate a lack of understanding.
+* Large, unfocused PRs that appear to be bulk AI-generated content.
+
+### Questions
+
+If you have questions about this policy or are unsure whether your use of AI tools requires disclosure, please contact the [maintainers](./MAINTAINERS).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,6 +2,8 @@
 
 This document defines the governance rules for the StreamsHub organization.
 
+For information on contributing to StreamsHub, including the AI contribution policy, see the [Contributing Guide](CONTRIBUTING.md).
+
 ## Organization structure
 
 The StreamsHub organization contains multiple sub-projects. 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This repository contains the governance documents for the StreamsHub organization and its sub-projects:
 
 * [Governance Policy](./GOVERNANCE.md)
+* [Contributing Guide](./CONTRIBUTING.md)
 * [List of Maintainers](./MAINTAINERS)
 * [List of Component Owners](./COMPONENT-OWNERS)
 * [List of Emeritus Maintainers and Component Owners](./EMERITUS)


### PR DESCRIPTION
With the increased usage of AI coding tools by maintainers, component owners, and contributors, the StreamsHub organisation needs a clear statement on how AI usage is permitted when contributing to our sub-projects. This PR addresses #5.

This policy was informed by:
- Strimzi AI policy [proposal](https://github.com/strimzi/governance/pull/29)
- Kroxylicious AI assistance [guidelines](https://github.com/kroxylicious/.github/blob/main/CONTRIBUTING.md#use-of-ai-assistance)
- Kubernetes AI [guidance](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance)

Key policy points:

- AI tools are permitted, but the contributor bears full responsibility for understanding and quality
- Substantial AI assistance requires disclosure via an Assisted-by commit trailer (following the Kroxylicious model)
- Co-authored-by, Signed-off-by, and similar trailers must not reference AI tools, as only humans can certify the DCO
- Contributors must not use AI to respond to reviewers or invoke AI review bots on project PRs
- PRs violating the policy may be closed

This PR adds a `CONTRIBUTING.md` to the Goverance repo. The idea is that this is a parent contributing document that sub-project specific contributing documents can reference. If accepted this document can also be referenced on the main StreamsHub website. 